### PR TITLE
Force CLI to use newline character rather than `\n`

### DIFF
--- a/lib/skylark/cli.rb
+++ b/lib/skylark/cli.rb
@@ -61,7 +61,7 @@ module Skylark
 
 							open(filename, 'wb') do |io|
 								io.write JSON.pretty_generate(hash)
-								io.write '\n'
+								io.write "\n"
 							end
 						end
 					end


### PR DESCRIPTION
*Closes #14.*